### PR TITLE
Append Url with & and query string instead of ? if QS already present

### DIFF
--- a/src/Owin.Security.Saml/SamlMessage.cs
+++ b/src/Owin.Security.Saml/SamlMessage.cs
@@ -161,7 +161,7 @@ namespace Owin.Security.Saml
                     redirectBuilder.RelayState = context.Authentication.AuthenticationResponseChallenge.Properties.Dictionary.ToDelimitedString();
                 logger.DebugFormat(TraceMessages.AuthnRequestSent, redirectBuilder.Request);
 
-                var redirectLocation = request.Destination + "?" + redirectBuilder.ToQuery();
+                var redirectLocation = request.Destination + (request.Destination.Contains("?") ? "&" : "?") + redirectBuilder.ToQuery();
                 return redirectLocation;
             case BindingType.Post:
                 throw new NotImplementedException();

--- a/src/SAML2.AspNet/Protocol/Saml20LogoutHandler.cs
+++ b/src/SAML2.AspNet/Protocol/Saml20LogoutHandler.cs
@@ -328,7 +328,7 @@ namespace SAML2.Protocol
 
                 Logger.DebugFormat(TraceMessages.LogoutResponseSent, builder.Response);
 
-                context.Response.Redirect(destination.Url + "?" + builder.ToQuery(), true);
+                context.Response.Redirect(destination.Url + (destination.Url.Contains("?") ? "&" : "?") + builder.ToQuery(), true);
                 return;
             }
 
@@ -415,7 +415,7 @@ namespace SAML2.Protocol
                                       SigningKey = config.ServiceProvider.SigningCertificate.PrivateKey
                                   };
 
-                var redirectUrl = destination.Url + "?" + builder.ToQuery();
+                var redirectUrl = destination.Url + (destination.Url.Contains("?") ? "&" : "?") + builder.ToQuery();
                 Logger.DebugFormat(TraceMessages.LogoutRequestSent, idp.Id, "REDIRECT", redirectUrl);
 
                 context.Response.Redirect(redirectUrl, true);

--- a/src/SAML2.AspNet/Protocol/Saml20SignonHandler.cs
+++ b/src/SAML2.AspNet/Protocol/Saml20SignonHandler.cs
@@ -189,7 +189,7 @@ namespace SAML2.Protocol
 
                 Logger.DebugFormat(TraceMessages.AuthnRequestSent, redirectBuilder.Request);
 
-                var redirectLocation = request.Destination + "?" + redirectBuilder.ToQuery();
+                var redirectLocation = request.Destination + (request.Destination.Contains("?") ? "&" : "?") + redirectBuilder.ToQuery();
                 context.Response.Redirect(redirectLocation, true);
                 break;
             case BindingType.Post:

--- a/src/SAML2.Core/Bindings/HttpArtifactBindingBuilder.cs
+++ b/src/SAML2.Core/Bindings/HttpArtifactBindingBuilder.cs
@@ -176,7 +176,7 @@ namespace SAML2.Bindings
             var artifact = ArtifactUtil.CreateArtifact(HttpArtifactBindingConstants.ArtifactTypeCode, localEndpointIndex, sourceIdHash, messageHandle);
             cacheInsert(artifact, signedSamlMessage);
 
-            var destinationUrl = destination.Url + "?" + HttpArtifactBindingConstants.ArtifactQueryStringName + "=" + Uri.EscapeDataString(artifact);
+            var destinationUrl = destination.Url + (destination.Url.Contains("?") ? "&" : "?") + HttpArtifactBindingConstants.ArtifactQueryStringName + "=" + Uri.EscapeDataString(artifact);
             if (!string.IsNullOrEmpty(relayState))
             {
                 destinationUrl += "&relayState=" + relayState;


### PR DESCRIPTION
Hi,

I went the dummy route here (didn't add to instance functions / properties / utils) and simply replaced the problem areas with conditional evaluations to determine whether to append query string with ? or &.

If there is a better place to put some abstraction of this behavior in the library, let me know and I will fix this.

Resolves Issue #7.
