### PR TITLE
Fix for the RedirectUrl to handle urls with query params

### DIFF
--- a/src/Owin.Security.Saml.Test/DictionaryExtensionsTests.cs
+++ b/src/Owin.Security.Saml.Test/DictionaryExtensionsTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Owin.Security.Saml.Test
+{
+    /// <summary>
+    /// Unit test for <see cref="IDictionaryExtensions"/>
+    /// </summary>
+    [TestClass]
+    public class DictionaryExtensionsTests
+    {
+        [TestMethod]
+        public void EscapesValuesProperly()
+        {
+            const string key = ".return";
+            const string value = "http://localhost:9000/Auth/SignIn?returnUrl=http%3A%2F%2Flocalhost%3A9000%2F%23%2Fhome";
+            
+            
+            // arrange
+            var attributes = new Dictionary<string, string>()
+            {
+                {key, value}
+            };
+
+            // act
+            var attributesAsString = attributes.ToDelimitedString();
+            var newAttributesFromString = attributesAsString.FromDelimitedString().ToDictionary(x => x.Key, x => x.Value);
+
+            // assert
+            Assert.AreEqual(attributes[key], newAttributesFromString[key]);
+        }
+    }
+}

--- a/src/Owin.Security.Saml.Test/Owin.Security.Saml.Test.csproj
+++ b/src/Owin.Security.Saml.Test/Owin.Security.Saml.Test.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9577677C-0E39-45C5-945D-8B18B8A761E4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Owin.Security.Saml.Test</RootNamespace>
+    <AssemblyName>Owin.Security.Saml.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="DictionaryExtensionsTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Owin.Security.Saml\Owin.Security.Saml.csproj">
+      <Project>{0054dafd-1a69-4807-b24e-a6a6b71927c7}</Project>
+      <Name>Owin.Security.Saml</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Owin.Security.Saml.Test/Properties/AssemblyInfo.cs
+++ b/src/Owin.Security.Saml.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Owin.Security.Saml.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Owin.Security.Saml.Test")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("bc5882bb-f848-44c8-a790-6675d288e7c6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Owin.Security.Saml/IDictionaryExtensions.cs
+++ b/src/Owin.Security.Saml/IDictionaryExtensions.cs
@@ -21,7 +21,7 @@ namespace Owin.Security.Saml
         public static string ToDelimitedString<TKey, TValue>(this IDictionary<TKey, TValue> value)
         {
             if (value == null) throw new ArgumentNullException("value");
-            return string.Join("&", value.Select(kvp => string.Format("{0}={1}", kvp.Key, kvp.Value)));
+            return string.Join("&", value.Select(kvp => string.Format("{0}={1}", kvp.Key, Uri.EscapeDataString(kvp.Value.ToString()))));
         }
 
         public static IEnumerable<KeyValuePair<string,string>> FromDelimitedString(this string value)
@@ -29,7 +29,7 @@ namespace Owin.Security.Saml
             if (value == null) throw new ArgumentNullException("value");
             return value.Split('&').Select(kvp => {
                 var split = kvp.Split('=');
-                return new KeyValuePair<string, string>(split[0], split[1]);
+                return new KeyValuePair<string, string>(split[0], Uri.UnescapeDataString(split[1]));
             });
         }
     }

--- a/src/SAML2.sln
+++ b/src/SAML2.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SAML2.AspNet", "SAML2.AspNe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SelfHostOwinSPExample", "SelfHostOwinSPExample\SelfHostOwinSPExample.csproj", "{6A489386-AFB0-4172-ACF4-61F79DC340DC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Owin.Security.Saml.Test", "Owin.Security.Saml.Test\Owin.Security.Saml.Test.csproj", "{9577677C-0E39-45C5-945D-8B18B8A761E4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{6A489386-AFB0-4172-ACF4-61F79DC340DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A489386-AFB0-4172-ACF4-61F79DC340DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A489386-AFB0-4172-ACF4-61F79DC340DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9577677C-0E39-45C5-945D-8B18B8A761E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9577677C-0E39-45C5-945D-8B18B8A761E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9577677C-0E39-45C5-945D-8B18B8A761E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9577677C-0E39-45C5-945D-8B18B8A761E4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
For the SignOn flow, when the return url contained an equals (=) sign (e.g. url with query params) it was cut off after the first equals sign.

For example this was my return url:
/Auth/SignIn?param1=http%3A%2F%2Flocalhost%3A9000%2F%23%2Fhome

When the SignOn response came in, this library was redirecting to:
/Auth/SignIn?param1=

Internally the RelayState was using equals (=) to express key-value pairs, but the value was not escaping any potential equal signs.

Have a look at my unit test.
