### PR TITLE
Protect against needless exception

### DIFF
--- a/src/Owin.Security.Saml/SamlLoginHandler.cs
+++ b/src/Owin.Security.Saml/SamlLoginHandler.cs
@@ -160,7 +160,7 @@ namespace Owin
             };
 
             var relayState = requestParams["RelayState"];
-            if (relayState != null) {
+            if (!string.IsNullOrEmpty(relayState)) {
                 var challengeProperties = new AuthenticationProperties(Compression.DeflateDecompress(relayState).FromDelimitedString().ToDictionary(k => k.Key, v => v.Value));
                 if (challengeProperties.RedirectUri != null) authenticationProperties.RedirectUri = challengeProperties.RedirectUri;
                 foreach (var kvp in challengeProperties.Dictionary.Except(authenticationProperties.Dictionary))


### PR DESCRIPTION
If relayState is an empty string, an exception would occur. This change protects against that case.