### PR TITLE
Optional ServiceProvider.SigningCertificate

### DIFF
--- a/OwinSecuritySamlNupkg.ps1
+++ b/OwinSecuritySamlNupkg.ps1
@@ -7,7 +7,8 @@ param(
 
 # Tool locations
 $nuget = ".\tools\NuGet.exe"
-$msbuild = "C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe"
+#$msbuild = "C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe"
+$msbuild = "& 'C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe'";
 
 # RegEx strings
 $assemblyVersionPattern = '^\[assembly: AssemblyVersion\("[0-9]+(\.([0-9]+|\*)){1,3}"\)\]$'
@@ -57,7 +58,7 @@ Invoke-Expression "$msbuild $solution /p:Configuration=Debug /p:Platform=`"Any C
 Invoke-Expression "$msbuild $solution /p:Configuration=Release /p:Platform=`"Any CPU`" /t:Clean"
 
 # Optional: Build
-# Invoke-Expression "$msbuild $solution /p:Configuration=Release /p:Platform=`"Any CPU`" /t:Build"
+Invoke-Expression "$msbuild $solution /p:Configuration=Release /p:Platform=`"Any CPU`" /t:Build"
 
 # Optional: Run unit tests
 # Invoke-Expression ".\src\packages\NUnit.Runners\tools\nunit.exe"

--- a/Saml2CoreNupkg.ps1
+++ b/Saml2CoreNupkg.ps1
@@ -7,7 +7,8 @@ param(
 
 # Tool locations
 $nuget = ".\tools\NuGet.exe"
-$msbuild = "C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe"
+#$msbuild = "C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe"
+$msbuild = "& 'C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe'";
 
 # RegEx strings
 $assemblyVersionPattern = '^\[assembly: AssemblyVersion\("[0-9]+(\.([0-9]+|\*)){1,3}"\)\]$'

--- a/src/Owin.Security.Saml/Owin.Security.Saml.nuspec
+++ b/src/Owin.Security.Saml/Owin.Security.Saml.nuspec
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0"?>
 <package >
   <metadata>
-    <id>$id$</id>
+    <id>scott.munro.$id$</id>
     <version>$version$</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>
-    <licenseUrl>https://github.com/elerch/SAML2/blob/master/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/elerch/SAML2</projectUrl>
+    <licenseUrl>https://github.com/samunro/SAML2/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/samunro/SAML2</projectUrl>
     <description>$description$</description>
     <releaseNotes>Working SP-Initiated requests against testshib.org (redirect binding)</releaseNotes>
     <copyright>Copyright 2015</copyright>
     <tags>SAML2 Owin library</tags>
     <dependencies>
-      <dependency id="Saml2.Core" version="0.9.0.0" />
+      <dependency id="scott.munro.Saml2.Core" version="1.0.0.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Owin.Security.Saml/Owin.Security.Saml.nuspec
+++ b/src/Owin.Security.Saml/Owin.Security.Saml.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2015</copyright>
     <tags>SAML2 Owin library</tags>
     <dependencies>
-      <dependency id="scott.munro.Saml2.Core" version="1.0.0.0" />
+      <dependency id="scott.munro.Saml2.Core" version="1.2.0.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Owin.Security.Saml/Properties/AssemblyInfo.cs
+++ b/src/Owin.Security.Saml/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/src/Owin.Security.Saml/SamlAuthenticationHandler.cs
+++ b/src/Owin.Security.Saml/SamlAuthenticationHandler.cs
@@ -109,7 +109,8 @@ namespace Owin.Security.Saml
             AuthenticationProperties properties = challenge.Properties;
             if (string.IsNullOrEmpty(properties.RedirectUri))
             {
-                properties.RedirectUri = currentUri;
+                properties.RedirectUri = !string.IsNullOrWhiteSpace(Options.RedirectAfterLogin) ? Options.RedirectAfterLogin : currentUri;
+
                 if (_logger.IsEnabled(TraceEventType.Verbose))
                 {
                     _logger.WriteVerbose(string.Format("Setting the RedirectUri to {0}.", properties.RedirectUri));

--- a/src/Owin.Security.Saml/SamlMessage.cs
+++ b/src/Owin.Security.Saml/SamlMessage.cs
@@ -150,7 +150,7 @@ namespace Owin.Security.Saml
 
                 var redirectBuilder = new HttpRedirectBindingBuilder
                 {
-                    SigningKey = config.ServiceProvider.SigningCertificate.PrivateKey,
+                    SigningKey = config.ServiceProvider.SigningCertificate?.PrivateKey,
                     Request = request.GetXml().OuterXml
                 };
                 if (context.Authentication != null &&

--- a/src/SAML2.Core/Properties/AssemblyInfo.cs
+++ b/src/SAML2.Core/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/src/SAML2.Core/SAML2.Core.csproj
+++ b/src/SAML2.Core/SAML2.Core.csproj
@@ -170,7 +170,9 @@
     <Compile Include="Schema\Metadata\PdpDescriptor.cs" />
     <Compile Include="Schema\Metadata\RequestedAttribute.cs" />
     <Compile Include="Schema\Metadata\RoleDescriptor.cs" />
+    <Compile Include="Schema\Metadata\ApplicationServiceType.cs" />
     <Compile Include="Schema\Metadata\SpSsoDescriptor.cs" />
+    <Compile Include="Schema\Metadata\SecurityTokenServiceType.cs" />
     <Compile Include="Schema\Metadata\SsoDescriptor.cs" />
     <Compile Include="Schema\Protocol\ArtifactResolve.cs" />
     <Compile Include="Schema\Protocol\ArtifactResponse.cs" />

--- a/src/SAML2.Core/SAML2.Core.nuspec
+++ b/src/SAML2.Core/SAML2.Core.nuspec
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0"?>
 <package >
   <metadata>
-    <id>$id$</id>
+    <id>scott.munro.$id$</id>
     <version>$version$</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>
-    <licenseUrl>https://github.com/elerch/SAML2/blob/master/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/elerch/SAML2</projectUrl>
+    <licenseUrl>https://github.com/samunro/SAML2/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/samunro/SAML2</projectUrl>
     <description>$description$</description>
     <releaseNotes>Working SP-Initiated requests against testshib.org (redirect binding)</releaseNotes>
     <copyright>Copyright 2015</copyright>

--- a/src/SAML2.Core/Saml20Assertion.cs
+++ b/src/SAML2.Core/Saml20Assertion.cs
@@ -611,7 +611,14 @@ namespace SAML2
         /// <param name="trustedSigners">The trusted signers.</param>
         private void LoadXml(XmlElement element, IEnumerable<AsymmetricAlgorithm> trustedSigners, Saml2Configuration config)
         {
-            XmlAssertion = element;
+            //If the assertion element belongs to a larger document then it would be a hash of that document that would be used when checking the signature.
+            //Create a new, smaller document that contains only the assertion so that it is a hash of the assertion that is used.
+            var xmlDocument = new XmlDocument() { PreserveWhitespace = true };
+
+            xmlDocument.LoadXml(element.OuterXml);
+
+            XmlAssertion = xmlDocument.DocumentElement;
+
             if (trustedSigners != null)
             {
                 if (!CheckSignature(trustedSigners))

--- a/src/SAML2.Core/Saml20Constants.cs
+++ b/src/SAML2.Core/Saml20Constants.cs
@@ -25,6 +25,8 @@ namespace SAML2
         /// </summary>
         public const string Metadata = "urn:oasis:names:tc:SAML:2.0:metadata";
 
+        public const string WsFederationNamespace = "http://docs.oasis-open.org/wsfed/federation/200706";
+
         /// <summary>
         /// The XML namespace of <c>XmlDSig</c>
         /// </summary>

--- a/src/SAML2.Core/Schema/Metadata/ApplicationServiceType.cs
+++ b/src/SAML2.Core/Schema/Metadata/ApplicationServiceType.cs
@@ -1,0 +1,7 @@
+using System.Xml.Serialization;
+
+namespace SAML2.Schema.Metadata
+{
+    [XmlType(Namespace = Saml20Constants.WsFederationNamespace)]
+    public class ApplicationServiceType: RoleDescriptor {}
+}

--- a/src/SAML2.Core/Schema/Metadata/RoleDescriptor.cs
+++ b/src/SAML2.Core/Schema/Metadata/RoleDescriptor.cs
@@ -17,6 +17,8 @@ namespace SAML2.Schema.Metadata
     [XmlInclude(typeof(SsoDescriptor))]
     [XmlInclude(typeof(SpSsoDescriptor))]
     [XmlInclude(typeof(IdpSsoDescriptor))]    
+    [XmlInclude(typeof(SecurityTokenServiceType))]    
+    [XmlInclude(typeof(ApplicationServiceType))]    
     [Serializable]
     [XmlType(Namespace = Saml20Constants.Metadata)]
     [XmlRoot(ElementName, Namespace = Saml20Constants.Metadata, IsNullable = false)]

--- a/src/SAML2.Core/Schema/Metadata/SecurityTokenServiceType.cs
+++ b/src/SAML2.Core/Schema/Metadata/SecurityTokenServiceType.cs
@@ -1,0 +1,8 @@
+using System.Xml.Serialization;
+
+namespace SAML2.Schema.Metadata
+{
+    [XmlType(Namespace = Saml20Constants.WsFederationNamespace)]
+    public class SecurityTokenServiceType: RoleDescriptor{}
+}
+

--- a/src/SAML2.Tests/SAML2.Tests.csproj
+++ b/src/SAML2.Tests/SAML2.Tests.csproj
@@ -132,12 +132,6 @@
     <None Include="Certificates\pingcertificate.crt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="Certificates\SafewhereTest_SFS.pfx">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <EmbeddedResource Include="Certificates\sts_dev_certificate.pfx">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SelfHostOwinSPExample/SelfHostOwinSPExample.csproj
+++ b/src/SelfHostOwinSPExample/SelfHostOwinSPExample.csproj
@@ -67,9 +67,6 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
-    <EmbeddedResource Include="sts_dev_certificate.pfx">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Owin.Security.Saml\Owin.Security.Saml.csproj">


### PR DESCRIPTION
I don't have much experience with SAML so please correct me if I have anything wrong.

From what I understand, signing requests that are sent to identity providers is optional (specific identity providers might require it).

The following guard clause in the HttpRedirectBindingBuilder.SigningKey setter seems to back this up - null is allowed.

```
                // Check if the key is of a supported type. [SAMLBind] sect. 3.4.4.1 specifies this.
                if (!(value is RSACryptoServiceProvider || value is DSA || value == null))
                {
                    throw new ArgumentException("Signing key must be an instance of either RSACryptoServiceProvider or DSA.");
                }
```

I was getting a null reference exception in this expression within SamlMessage.AuthnRequestForIdp() when I left the ServiceProvider's SigningCertificate property null.

`                    SigningKey = config.ServiceProvider.SigningCertificate.PrivateKey,
`

My change will result in the SigningKey being set to null if the ServiceProvider's SigningCertificate is null.