### PR TITLE
Default to RedirectAfterLogin in SamlAuthenticationHandler.ApplyResponseChallengeAsync

### DIFF
--- a/src/Owin.Security.Saml/SamlAuthenticationHandler.cs
+++ b/src/Owin.Security.Saml/SamlAuthenticationHandler.cs
@@ -109,7 +109,8 @@ namespace Owin.Security.Saml
             AuthenticationProperties properties = challenge.Properties;
             if (string.IsNullOrEmpty(properties.RedirectUri))
             {
-                properties.RedirectUri = currentUri;
+                properties.RedirectUri = !string.IsNullOrWhiteSpace(Options.RedirectAfterLogin) ? Options.RedirectAfterLogin : currentUri;
+
                 if (_logger.IsEnabled(TraceEventType.Verbose))
                 {
                     _logger.WriteVerbose(string.Format("Setting the RedirectUri to {0}.", properties.RedirectUri));


### PR DESCRIPTION
The current default is currentUri which does not seem like the best choice if a value for RedirectAfterLogin is available.

I was expecting the browser to be redirected to RedirectAfterLogin post authentication but I actually saw an endless loop of authentications because it was redirecting to currentUri.